### PR TITLE
Include as a package with an index.js.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ module.exports = function (target, dir, optsOrEx) {
     if (!target) throw new Error('Target name required');
     if (!dir) throw new Error('Directory or files required');
     
+    var dst = path.normalize('/node_modules/' + target + '/index.js');
+    
     var opts = typeof optsOrEx === 'object' && !Array.isArray(optsOrEx)
         ? optsOrEx
         : { extension : optsOrEx }
@@ -87,8 +89,6 @@ module.exports = function (target, dir, optsOrEx) {
         findit.sync(dir, finder);
         
         var include = function (files) {
-            var dst = path.normalize('/node_modules/' + target);
-            
             Object.keys(bundle.files).forEach(function (key) {
                 if (bundle.files[key].target === dst) {
                     delete bundle.files[key];


### PR DESCRIPTION
Browserify [checks for index.js, package.json][0], but not the set-up fileify uses. The README example may work, but when including `files` from within browserify `require()`'d modules, browserify complains the module doesn't exist.
 
 [0]: https://github.com/substack/node-browserify/blob/65a5ccbd65237fb062ce934dc252bb16d3438a6c/lib/wrap.js#L324